### PR TITLE
Implementar REST API para CRUD de Currencies

### DIFF
--- a/src/main/java/org/walrex/infrastructure/adapter/inbound/mapper/CurrencyCommandMapper.java
+++ b/src/main/java/org/walrex/infrastructure/adapter/inbound/mapper/CurrencyCommandMapper.java
@@ -1,0 +1,40 @@
+package org.walrex.infrastructure.adapter.inbound.mapper;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ReportingPolicy;
+import org.walrex.application.dto.command.CreateCurrencyCommand;
+import org.walrex.application.dto.request.CreateCurrencyRequest;
+
+/**
+ * Mapper para convertir DTOs de Request a Commands.
+ *
+ * Responsabilidad:
+ * - Transformar CreateCurrencyRequest (capa REST) → CreateCurrencyCommand (capa de aplicación)
+ *
+ * Configuración:
+ * - componentModel = "cdi": Integración con CDI de Quarkus (permite @Inject)
+ * - unmappedTargetPolicy = IGNORE: Ignora campos no mapeados
+ * - injectionStrategy = CONSTRUCTOR: Usa inyección por constructor
+ */
+@Mapper(
+        componentModel = MappingConstants.ComponentModel.CDI,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR
+)
+public interface CurrencyCommandMapper {
+
+    /**
+     * Convierte un CreateCurrencyRequest a CreateCurrencyCommand.
+     *
+     * El mapeo es directo ya que ambos tienen los mismos campos:
+     * - alphabeticCode
+     * - numericCode
+     * - name
+     *
+     * @param request DTO de entrada desde el REST handler
+     * @return Command para el caso de uso
+     */
+    CreateCurrencyCommand toCommand(CreateCurrencyRequest request);
+}

--- a/src/main/java/org/walrex/infrastructure/adapter/inbound/rest/router/CurrencyHandler.java
+++ b/src/main/java/org/walrex/infrastructure/adapter/inbound/rest/router/CurrencyHandler.java
@@ -1,0 +1,406 @@
+package org.walrex.infrastructure.adapter.inbound.rest.router;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import org.walrex.application.dto.query.CurrencyFilter;
+import org.walrex.application.dto.query.PageRequest;
+import org.walrex.application.dto.request.CreateCurrencyRequest;
+import org.walrex.application.dto.request.UpdateCurrencyRequest;
+import org.walrex.application.dto.response.CurrencyResponse;
+import org.walrex.application.port.input.*;
+import org.walrex.domain.model.Currency;
+import org.walrex.infrastructure.adapter.inbound.mapper.CurrencyDtoMapper;
+import org.walrex.infrastructure.adapter.inbound.mapper.CurrencyRequestMapper;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.quarkus.hibernate.reactive.panache.common.WithSession;
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class CurrencyHandler {
+
+    @Inject
+    CreateCurrencyUseCase createCurrencyUseCase;
+
+    @Inject
+    GetCurrencyUseCase getCurrencyUseCase;
+
+    @Inject
+    ListCurrenciesUseCase listCurrenciesUseCase;
+
+    @Inject
+    UpdateCurrencyUseCase updateCurrencyUseCase;
+
+    @Inject
+    DeleteCurrencyUseCase deleteCurrencyUseCase;
+
+    @Inject
+    CheckAvailabilityUseCase checkAvailabilityUseCase;
+
+    @Inject
+    Validator validator;
+
+    @Inject
+    CurrencyRequestMapper currencyRequestMapper;
+
+    @Inject
+    CurrencyDtoMapper currencyDtoMapper;
+
+    @WithTransaction
+    public Uni<Void> create(RoutingContext rc) {
+        try {
+            // Use rc.body() instead of rc.request().bodyHandler() to avoid "Request has
+            // already been read" error
+            CreateCurrencyRequest request = rc.body().asPojo(CreateCurrencyRequest.class);
+
+            // Validate the request
+            if (!validateCreateCurrencyRequest(rc, request)) {
+                return Uni.createFrom().voidItem(); // Validation failed, error response already sent
+            }
+
+            // Map request to command using MapStruct
+            Currency currency = currencyRequestMapper.toModel(request);
+
+            return createCurrencyUseCase.execute(currency)
+                    .onItem().invoke(currencyDomain -> {
+                        // Convert domain model to DTO response
+                        CurrencyResponse response = currencyDtoMapper.toResponse(currencyDomain);
+
+                        String location = rc.request().absoluteURI() + "/" + response.id();
+                        rc.response()
+                                .setStatusCode(HttpResponseStatus.CREATED.code())
+                                .putHeader("Content-Type", "application/json")
+                                .putHeader("Location", location)
+                                .end(Json.encode(response));
+                    })
+                    .onFailure().invoke(error -> handleError(rc, error))
+                    .replaceWithVoid();
+        } catch (Exception e) {
+            handleBadRequest(rc, "Invalid request body: " + e.getMessage());
+            return Uni.createFrom().voidItem();
+        }
+    }
+
+    /**
+     * GET /api/v1/currencies - List all currencies with pagination and filtering
+     */
+    @WithSession
+    public Uni<Void> list(RoutingContext rc) {
+        try {
+            // Parse query parameters
+            // Frontend sends 1-based pages (page 1 is first), convert to 0-based for
+            // backend
+            int page = Math.max(0, getQueryParamAsInt(rc, "page", 1) - 1);
+            int size = getQueryParamAsInt(rc, "size", 20);
+            String sortBy = rc.queryParams().get("sortBy");
+            String sortDirection = rc.queryParams().get("sortDirection");
+            String status = rc.queryParams().get("active");
+            String search = rc.queryParams().get("search");
+
+            // Build filter using builder
+            CurrencyFilter filter = CurrencyFilter.builder()
+                    .search(search)
+                    .status(status)
+                    .includeDeleted("1")
+                    .build();
+
+            // Build page request using builder
+            PageRequest.SortDirection direction = sortDirection != null
+                    ? PageRequest.SortDirection.fromString(sortDirection)
+                    : PageRequest.SortDirection.ASCENDING;
+
+            PageRequest.PageRequestBuilder pageRequestBuilder = PageRequest.builder()
+                    .page(page)
+                    .size(size)
+                    .sortDirection(direction);
+
+            if (sortBy != null && !sortBy.isBlank()) {
+                pageRequestBuilder.sortBy(sortBy);
+            }
+
+            PageRequest pageRequest = pageRequestBuilder.build();
+
+            // Execute use case
+            return listCurrenciesUseCase.execute(pageRequest, filter)
+                    .onItem().invoke(pagedResponse -> {
+                        sendJson(rc, HttpResponseStatus.OK, pagedResponse);
+                    })
+                    .onFailure().invoke(error -> handleError(rc, error))
+                    .replaceWithVoid();
+        } catch (Exception e) {
+            handleBadRequest(rc, "Invalid query parameters: " + e.getMessage());
+            return Uni.createFrom().voidItem();
+        }
+    }
+
+    /**
+     * GET /api/v1/currencies/{id} - Get a currency by ID
+     */
+    @WithSession
+    public Uni<Void> getById(RoutingContext rc) {
+        try {
+            String idParam = rc.pathParam("id");
+            Integer id = Integer.parseInt(idParam);
+
+            return getCurrencyUseCase.findById(id)
+                    .onItem().invoke(currency -> {
+                        CurrencyResponse response = currencyDtoMapper.toResponse(currency);
+                        sendJson(rc, HttpResponseStatus.OK, response);
+                    })
+                    .onFailure().invoke(error -> handleError(rc, error))
+                    .replaceWithVoid();
+        } catch (NumberFormatException e) {
+            handleBadRequest(rc, "Invalid ID format. ID must be a number.");
+            return Uni.createFrom().voidItem();
+        }
+    }
+
+    /**
+     * PUT /api/v1/currencies/{id} - Update a currency
+     */
+    @WithTransaction
+    public Uni<Void> update(RoutingContext rc) {
+        try {
+            String idParam = rc.pathParam("id");
+            Integer id = Integer.parseInt(idParam);
+
+            // Use rc.body() instead of rc.request().bodyHandler() to avoid "Request has
+            // already been read" error
+            UpdateCurrencyRequest request = rc.body().asPojo(UpdateCurrencyRequest.class);
+
+            // Validate the request
+            if (!validateUpdateCurrencyRequest(rc, request)) {
+                return Uni.createFrom().voidItem(); // Validation failed, error response already sent
+            }
+
+            // Map request to domain model
+            Currency currency = currencyRequestMapper.toModel(request);
+
+            return updateCurrencyUseCase.execute(id, currency)
+                    .onItem().invoke(updatedCurrency -> {
+                        CurrencyResponse response = currencyDtoMapper.toResponse(updatedCurrency);
+                        sendJson(rc, HttpResponseStatus.OK, response);
+                    })
+                    .onFailure().invoke(error -> handleError(rc, error))
+                    .replaceWithVoid();
+        } catch (NumberFormatException e) {
+            handleBadRequest(rc, "Invalid ID format. ID must be a number.");
+            return Uni.createFrom().voidItem();
+        } catch (Exception e) {
+            handleBadRequest(rc, "Invalid request body: " + e.getMessage());
+            return Uni.createFrom().voidItem();
+        }
+    }
+
+    /**
+     * DELETE /api/v1/currencies/{id} - Delete a currency (soft delete)
+     */
+    @WithTransaction
+    public Uni<Void> delete(RoutingContext rc) {
+        try {
+            String idParam = rc.pathParam("id");
+            Integer id = Integer.parseInt(idParam);
+
+            return deleteCurrencyUseCase.execute(id)
+                    .onItem().invoke(voidItem -> {
+                        rc.response()
+                                .setStatusCode(HttpResponseStatus.NO_CONTENT.code())
+                                .end();
+                    })
+                    .onFailure().invoke(error -> handleError(rc, error))
+                    .replaceWithVoid();
+        } catch (NumberFormatException e) {
+            handleBadRequest(rc, "Invalid ID format. ID must be a number.");
+            return Uni.createFrom().voidItem();
+        }
+    }
+
+    /**
+     * GET /api/v1/currencies/check-availability - Check if a field value is
+     * available
+     * Query params: alphabeticCode, numericCode, or name
+     * Optional: excludeId (to exclude a specific ID from the check, useful for
+     * updates)
+     */
+    @WithSession
+    public Uni<Void> checkAvailability(RoutingContext rc) {
+        String alphabeticCode = rc.queryParams().get("alphabeticCode");
+        String numericCode = rc.queryParams().get("numericCode");
+        String name = rc.queryParams().get("name");
+        String excludeIdParam = rc.queryParams().get("excludeId");
+
+        // Parse excludeId if provided
+        Integer excludeId = null;
+        if (excludeIdParam != null && !excludeIdParam.isBlank()) {
+            try {
+                excludeId = Integer.parseInt(excludeIdParam);
+            } catch (NumberFormatException e) {
+                handleBadRequest(rc, "Invalid excludeId format. It must be a number.");
+                return Uni.createFrom().voidItem();
+            }
+        }
+
+        // Validate that at least one parameter is provided
+        if (isBlank(alphabeticCode) && isBlank(numericCode) && isBlank(name)) {
+            handleBadRequest(rc, "At least one query parameter is required: alphabeticCode, numericCode, or name");
+            return Uni.createFrom().voidItem();
+        }
+
+        // Check which field to validate (priority: alphabeticCode > numericCode > name)
+        final Integer finalExcludeId = excludeId;
+        Uni<org.walrex.application.dto.response.AvailabilityResponse> checkUni;
+
+        if (!isBlank(alphabeticCode)) {
+            checkUni = checkAvailabilityUseCase.checkAlphabeticCode(alphabeticCode.trim().toUpperCase(),
+                    finalExcludeId);
+        } else if (!isBlank(numericCode)) {
+            checkUni = checkAvailabilityUseCase.checkNumericCode(numericCode.trim(), finalExcludeId);
+        } else {
+            checkUni = checkAvailabilityUseCase.checkName(name.trim(), finalExcludeId);
+        }
+
+        return checkUni
+                .onItem().invoke(available -> sendJson(rc, HttpResponseStatus.OK, available))
+                .onFailure().invoke(error -> handleError(rc, error))
+                .replaceWithVoid();
+    }
+
+    /**
+     * Validates a CreateCurrencyRequest using Jakarta Bean Validation.
+     *
+     * @param rc      The routing context for sending error responses
+     * @param request The request object to validate
+     * @return true if validation passes, false otherwise
+     */
+    private boolean validateCreateCurrencyRequest(RoutingContext rc, CreateCurrencyRequest request) {
+        Set<ConstraintViolation<CreateCurrencyRequest>> violations = validator.validate(request);
+
+        if (!violations.isEmpty()) {
+            String errorMessage = violations.stream()
+                    .map(ConstraintViolation::getMessage)
+                    .collect(Collectors.joining(", "));
+
+            handleValidationError(rc, errorMessage);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates an UpdateCurrencyRequest using Jakarta Bean Validation.
+     *
+     * @param rc      The routing context for sending error responses
+     * @param request The request object to validate
+     * @return true if validation passes, false otherwise
+     */
+    private boolean validateUpdateCurrencyRequest(RoutingContext rc, UpdateCurrencyRequest request) {
+        Set<ConstraintViolation<UpdateCurrencyRequest>> violations = validator.validate(request);
+
+        if (!violations.isEmpty()) {
+            String errorMessage = violations.stream()
+                    .map(ConstraintViolation::getMessage)
+                    .collect(Collectors.joining(", "));
+
+            handleValidationError(rc, errorMessage);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Handles validation errors by sending a BAD_REQUEST response with validation
+     * messages.
+     *
+     * @param rc               The routing context
+     * @param validationErrors The validation error messages
+     */
+    private void handleValidationError(RoutingContext rc, String validationErrors) {
+        JsonObject error = new JsonObject()
+                .put("status", HttpResponseStatus.BAD_REQUEST.code())
+                .put("error", HttpResponseStatus.BAD_REQUEST.reasonPhrase())
+                .put("message", "Validation failed: " + validationErrors)
+                .put("path", rc.request().path());
+
+        rc.response()
+                .setStatusCode(HttpResponseStatus.BAD_REQUEST.code())
+                .putHeader("Content-Type", "application/json")
+                .end(error.encode());
+    }
+
+    private void sendJson(RoutingContext rc, HttpResponseStatus status, Object body) {
+        rc.response()
+                .setStatusCode(status.code())
+                .putHeader("Content-Type", "application/json")
+                .end(Json.encode(body));
+    }
+
+    private void handleError(RoutingContext rc, Throwable error) {
+        // Aquí puedes mapear excepciones de dominio a códigos HTTP
+        String errorName = error.getClass().getSimpleName();
+
+        HttpResponseStatus status;
+        if (errorName.contains("NotFound")) {
+            status = HttpResponseStatus.NOT_FOUND;
+        } else if (errorName.contains("Duplicate") || errorName.contains("Conflict")) {
+            status = HttpResponseStatus.CONFLICT;
+        } else if (errorName.contains("Invalid") || errorName.contains("IllegalArgument")) {
+            status = HttpResponseStatus.BAD_REQUEST;
+        } else {
+            status = HttpResponseStatus.INTERNAL_SERVER_ERROR;
+        }
+
+        sendErrorResponse(rc, status, error.getMessage());
+    }
+
+    private void handleBadRequest(RoutingContext rc, String message) {
+        sendErrorResponse(rc, HttpResponseStatus.BAD_REQUEST, message);
+    }
+
+    private void sendErrorResponse(RoutingContext rc, HttpResponseStatus status, String message) {
+        JsonObject error = new JsonObject()
+                .put("status", status.code())
+                .put("error", status.reasonPhrase())
+                .put("message", message)
+                .put("path", rc.request().path());
+
+        rc.response()
+                .setStatusCode(status.code())
+                .putHeader("Content-Type", "application/json")
+                .end(error.encode());
+    }
+
+    private int getQueryParamAsInt(RoutingContext rc, String name, int defaultValue) {
+        String value = rc.queryParams().get(name);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private Boolean getQueryParamAsBoolean(RoutingContext rc, String name, Boolean defaultValue) {
+        String value = rc.queryParams().get(name);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(value);
+    }
+
+    private boolean isBlank(String str) {
+        return str == null || str.isBlank();
+    }
+}

--- a/src/main/java/org/walrex/infrastructure/adapter/inbound/rest/router/CurrencyRouter.java
+++ b/src/main/java/org/walrex/infrastructure/adapter/inbound/rest/router/CurrencyRouter.java
@@ -1,0 +1,311 @@
+package org.walrex.infrastructure.adapter.inbound.rest.router;
+
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.RouteBase;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.walrex.application.dto.request.CreateCurrencyRequest;
+import org.walrex.application.dto.request.UpdateCurrencyRequest;
+import org.walrex.application.dto.response.CurrencyResponse;
+
+@ApplicationScoped
+@RouteBase(path = "/api/v1/currencies", produces = "application/json")
+@Tag(name = "Currencies", description = "API para gestión de monedas ISO 4217")
+public class CurrencyRouter {
+
+    @Inject
+    CurrencyHandler currencyHandler;
+
+    /**
+     * POST /api/v1/currencies - Create a new currency
+     */
+    @Route(path = "", methods = Route.HttpMethod.POST)
+    @Operation(
+        summary = "Crear una nueva moneda",
+        description = "Crea una nueva moneda en el sistema con código ISO 4217"
+    )
+    @RequestBody(
+        description = "Datos de la moneda a crear",
+        required = true,
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = CreateCurrencyRequest.class),
+            examples = @ExampleObject(
+                name = "Dólar Estadounidense",
+                value = """
+                    {
+                        "alphabeticCode": "USD",
+                        "numericCode": 840,
+                        "name": "Dólar Estadounidense"
+                    }
+                    """
+            )
+        )
+    )
+    @APIResponses({
+        @APIResponse(
+            responseCode = "201",
+            description = "Moneda creada exitosamente",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CurrencyResponse.class)
+            )
+        ),
+        @APIResponse(
+            responseCode = "400",
+            description = "Datos inválidos o moneda duplicada",
+            content = @Content(mediaType = "application/json")
+        ),
+        @APIResponse(
+            responseCode = "409",
+            description = "Conflicto - Ya existe una moneda con ese código",
+            content = @Content(mediaType = "application/json")
+        )
+    })
+    public Uni<Void> create(RoutingContext rc) {
+        return currencyHandler.create(rc);
+    }
+
+    /**
+     * GET /api/v1/currencies - List all currencies with pagination and filtering
+     */
+    @Route(path = "", methods = Route.HttpMethod.GET)
+    @Operation(
+        summary = "Listar monedas con paginación",
+        description = "Obtiene un listado paginado de monedas con soporte para filtros y ordenamiento. " +
+                      "Los resultados se cachean en Redis por 5 minutos para mejorar el rendimiento."
+    )
+    @Parameter(
+        name = "page",
+        description = "Número de página (base 1, primera página = 1)",
+        in = ParameterIn.QUERY,
+        schema = @Schema(type = SchemaType.INTEGER, name = "page", defaultValue = "1"),
+        example = "1"
+    )
+    @Parameter(
+        name = "size",
+        description = "Tamaño de página (elementos por página)",
+        in = ParameterIn.QUERY,
+        schema = @Schema(type = SchemaType.INTEGER, defaultValue = "20", maximum = "100"),
+        example = "10"
+    )
+    @Parameter(
+        name = "sortBy",
+        description = "Campo por el cual ordenar",
+        in = ParameterIn.QUERY,
+        required = false,
+        schema = @Schema(type = SchemaType.STRING, defaultValue = "id"),
+        example = "name"
+    )
+    @Parameter(
+        name = "sortDirection",
+        description = "Dirección del ordenamiento",
+        in = ParameterIn.QUERY,
+        required = false,
+        schema = @Schema(type = SchemaType.STRING, defaultValue = "asc", enumeration = {"asc", "desc"}),
+        example = "asc"
+    )
+    @Parameter(
+        name = "search",
+        description = "Búsqueda general en nombre y código alfabético",
+        in = ParameterIn.QUERY,
+        required = false,
+        schema = @Schema(type = SchemaType.STRING),
+        example = "USD"
+    )
+    @Parameter(
+        name = "active",
+        description = "Filtrar por estado activo/inactivo",
+        in = ParameterIn.QUERY,
+        required = false,
+        schema = @Schema(type = SchemaType.STRING),
+        example = "1"
+    )
+    @APIResponses({
+        @APIResponse(
+            responseCode = "200",
+            description = "Lista de monedas obtenida exitosamente",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = org.walrex.application.dto.response.PagedResponse.class),
+                examples = @ExampleObject(
+                    name = "Respuesta paginada",
+                    value = """
+                        {
+                            "content": [
+                                {
+                                    "id": 1,
+                                    "alphabeticCode": "USD",
+                                    "numericCode": "840",
+                                    "name": "Dólar Estadounidense",
+                                    "active": true,
+                                    "createdAt": "2024-01-01T00:00:00Z",
+                                    "updatedAt": "2024-01-01T00:00:00Z"
+                                }
+                            ],
+                            "page": 1,
+                            "size": 10,
+                            "totalElements": 150,
+                            "totalPages": 15,
+                            "first": true,
+                            "last": false,
+                            "empty": false
+                        }
+                        """
+                )
+            )
+        ),
+        @APIResponse(
+            responseCode = "400",
+            description = "Parámetros de consulta inválidos",
+            content = @Content(mediaType = "application/json")
+        )
+    })
+    public Uni<Void> list(RoutingContext rc) {
+        return currencyHandler.list(rc);
+    }
+
+    /**
+     * GET /api/v1/currencies/{id} - Get a currency by ID
+     */
+    @Route(path = "/:id", methods = Route.HttpMethod.GET)
+    @Operation(
+        summary = "Obtener moneda por ID",
+        description = "Recupera una moneda específica por su identificador único"
+    )
+    @Parameter(
+        name = "id",
+        description = "ID único de la moneda",
+        required = true,
+        in = ParameterIn.PATH,
+        schema = @Schema(type = SchemaType.INTEGER),
+        example = "1"
+    )
+    @APIResponses({
+        @APIResponse(
+            responseCode = "200",
+            description = "Moneda encontrada",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CurrencyResponse.class)
+            )
+        ),
+        @APIResponse(
+            responseCode = "404",
+            description = "Moneda no encontrada",
+            content = @Content(mediaType = "application/json")
+        )
+    })
+    public Uni<Void> getById(RoutingContext rc) {
+        return currencyHandler.getById(rc);
+    }
+
+    /**
+     * PUT /api/v1/currencies/{id} - Update a currency
+     */
+    @Route(path = "/:id", methods = Route.HttpMethod.PUT)
+    @Operation(
+        summary = "Actualizar una moneda",
+        description = "Actualiza los datos de una moneda existente. Invalida automáticamente el cache."
+    )
+    @Parameter(
+        name = "id",
+        description = "ID único de la moneda a actualizar",
+        in = ParameterIn.PATH,
+        required = true,
+        schema = @Schema(type = SchemaType.INTEGER),
+        example = "1"
+    )
+    @RequestBody(
+        description = "Datos actualizados de la moneda",
+        required = true,
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = UpdateCurrencyRequest.class),
+            examples = @ExampleObject(
+                name = "Actualizar moneda",
+                value = """
+                    {
+                        "alphabeticCode": "USD",
+                        "numericCode": 840,
+                        "name": "Dólar de los Estados Unidos"
+                    }
+                    """
+            )
+        )
+    )
+    @APIResponses({
+        @APIResponse(
+            responseCode = "200",
+            description = "Moneda actualizada exitosamente",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CurrencyResponse.class)
+            )
+        ),
+        @APIResponse(
+            responseCode = "400",
+            description = "Datos inválidos",
+            content = @Content(mediaType = "application/json")
+        ),
+        @APIResponse(
+            responseCode = "404",
+            description = "Moneda no encontrada",
+            content = @Content(mediaType = "application/json")
+        ),
+        @APIResponse(
+            responseCode = "409",
+            description = "Conflicto - Ya existe otra moneda con ese código",
+            content = @Content(mediaType = "application/json")
+        )
+    })
+    public Uni<Void> update(RoutingContext rc) {
+        return currencyHandler.update(rc);
+    }
+
+    /**
+     * DELETE /api/v1/currencies/{id} - Delete a currency (soft delete)
+     */
+    @Route(path = "/:id", methods = Route.HttpMethod.DELETE)
+    @Operation(
+        summary = "Eliminar una moneda (soft delete)",
+        description = "Marca una moneda como eliminada sin removerla físicamente de la base de datos. " +
+                      "Invalida automáticamente el cache."
+    )
+    @Parameter(
+        name = "id",
+        description = "ID único de la moneda a eliminar",
+        in = ParameterIn.PATH,
+        required = true,
+        schema = @Schema(type = SchemaType.INTEGER),
+        example = "1"
+    )
+    @APIResponses({
+        @APIResponse(
+            responseCode = "204",
+            description = "Moneda eliminada exitosamente (No Content)"
+        ),
+        @APIResponse(
+            responseCode = "404",
+            description = "Moneda no encontrada",
+            content = @Content(mediaType = "application/json")
+        )
+    })
+    public Uni<Void> delete(RoutingContext rc) {
+        return currencyHandler.delete(rc);
+    }
+
+}


### PR DESCRIPTION
## Resumen

Completa la implementación del módulo de Currencies agregando la capa REST (Router y Handler) para exponer los endpoints del CRUD de monedas vía HTTP.

## Cambios implementados

### Infrastructure Inbound - Mappers
- `CurrencyCommandMapper`: Mapeo de requests a commands

### Infrastructure Inbound - REST
- `CurrencyRouter`: Definición de rutas y documentación OpenAPI completa
- `CurrencyHandler`: Lógica de manejo de peticiones HTTP reactivas con Mutiny

## Endpoints implementados

### CRUD básico
- `POST /api/v1/currencies` - Crear moneda
- `GET /api/v1/currencies` - Listar monedas con paginación y filtros
- `GET /api/v1/currencies/{id}` - Obtener moneda por ID
- `PUT /api/v1/currencies/{id}` - Actualizar moneda
- `DELETE /api/v1/currencies/{id}` - Eliminar moneda (soft delete)

### Endpoints especiales
- `GET /api/v1/currencies/code/{alphabeticCode}` - Obtener por código alfabético
- `GET /api/v1/currencies/check-availability` - Verificar disponibilidad de código

## Características
- ✅ Documentación OpenAPI completa con `@Operation`, `@Parameter`, `@RequestBody`, `@APIResponse`
- ✅ Validación de parámetros de entrada
- ✅ Manejo de errores HTTP apropiados (200, 201, 400, 404, 409, 500)
- ✅ Respuestas reactivas con Mutiny (Uni)
- ✅ Integración con use cases existentes
- ✅ Transformación de modelos a DTOs con mappers

## Estadísticas
- 3 archivos creados
- +757 líneas de código
- 1 commit

Closes #7