### PR TITLE
fix: corregir mapeo de campos en entidades Customer, User y OTP

### DIFF
--- a/src/main/java/org/walrex/domain/model/Otp.java
+++ b/src/main/java/org/walrex/domain/model/Otp.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 @AllArgsConstructor
 @ToString
 public class Otp {
+    private Long id;
     private String referenceId;
     private OtpPurpose purpose;
     private String target;

--- a/src/main/java/org/walrex/domain/model/User.java
+++ b/src/main/java/org/walrex/domain/model/User.java
@@ -28,7 +28,7 @@ public class User {
     private OffsetDateTime pinLockedUntil;
 
     /** Estado */
-    private boolean active;
+    private Integer active;
 
     /** MFA / biometría (futuro) */
     private boolean mfaEnabled;

--- a/src/main/java/org/walrex/infrastructure/adapter/inbound/mapper/RegisterUserMapper.java
+++ b/src/main/java/org/walrex/infrastructure/adapter/inbound/mapper/RegisterUserMapper.java
@@ -30,7 +30,7 @@ public interface RegisterUserMapper {
     @Mapping(target = "usernameType", source = "request.identificationMethod", qualifiedByName = "mapUsernameType")
     @Mapping(target = "pinHash", source = "request.pinHash")
     @Mapping(target = "pinAttempts", constant = "0")
-    @Mapping(target = "active", constant = "true")
+    @Mapping(target = "active", constant = "1")
     User toUser(RegisterUserRequest request, Integer customerId);
 
     @Named("buildLastName")

--- a/src/main/java/org/walrex/infrastructure/adapter/outbound/persistence/OtpPersistenceAdapter.java
+++ b/src/main/java/org/walrex/infrastructure/adapter/outbound/persistence/OtpPersistenceAdapter.java
@@ -42,6 +42,9 @@ public class OtpPersistenceAdapter implements OtpRepositoryPort {
 
     @Override
     public Uni<Void> update(Otp otp) {
-        return save(otp).replaceWithVoid();
+        OtpEntity entity = mapper.toEntity(otp);
+        return repository.getSession()
+                .flatMap(session -> session.merge(entity))
+                .replaceWithVoid();
     }
 }

--- a/src/main/java/org/walrex/infrastructure/adapter/outbound/persistence/entity/CustomerEntity.java
+++ b/src/main/java/org/walrex/infrastructure/adapter/outbound/persistence/entity/CustomerEntity.java
@@ -74,7 +74,7 @@ public class CustomerEntity extends PanacheEntityBase {
     @Column(name = "id_distrito")
     private Integer idCountryDistrict;
 
-    @Column(name = "phone_mobile")
+    @Column(name = "phonemobile")
     private String phoneMobile;
 
     @Column(name = "phone_number")

--- a/src/main/java/org/walrex/infrastructure/adapter/outbound/persistence/entity/UserEntity.java
+++ b/src/main/java/org/walrex/infrastructure/adapter/outbound/persistence/entity/UserEntity.java
@@ -43,8 +43,8 @@ public class UserEntity extends PanacheEntityBase {
     private OffsetDateTime pinLockedUntil;
 
     @Builder.Default
-    @Column(nullable = false)
-    private Boolean active = true;
+    @Column(name = "status", nullable = false)
+    private Integer active = 1;
 
     @Builder.Default
     @Column(name = "mfa_enabled", nullable = false)

--- a/src/main/java/org/walrex/infrastructure/adapter/outbound/persistence/mapper/UserEntityMapper.java
+++ b/src/main/java/org/walrex/infrastructure/adapter/outbound/persistence/mapper/UserEntityMapper.java
@@ -11,6 +11,7 @@ import org.walrex.infrastructure.adapter.outbound.persistence.entity.UserEntity;
 public interface UserEntityMapper {
 
     @Mapping(target = "id", ignore = true)
+    @Mapping(target = "clientId", source = "customerId")
     UserEntity toEntity(User user);
 
     User toDomain(UserEntity entity);


### PR DESCRIPTION
## Summary

- Corrige el mapeo del campo `phonemobile` en `CustomerEntity` para que coincida con la columna de la BD
- Ajusta el campo `active` en `User` y `UserEntity` de `boolean/Boolean` a `Integer` mapeando a la columna `status`
- Agrega propiedad `id` al modelo de dominio `Otp` y usa `session.merge()` en `OtpPersistenceAdapter.update()` para evitar la creación de registros duplicados
- Corrige mapeo de `clientId` desde `customerId` en `UserEntityMapper`

## Test plan

- [ ] Verificar que el registro de clientes funciona correctamente sin error 500
- [ ] Verificar que el campo `phone_number` se almacena correctamente en la BD
- [ ] Verificar que la validación de OTP actualiza el registro existente en lugar de crear uno nuevo
- [ ] Verificar que el campo `status` de usuarios se persiste correctamente como Integer

Closes #69