### PR TITLE
Mejoras en cálculo de tasas de cambio (MIN, MAX, PROMEDIO)

### DIFF
--- a/src/main/java/org/walrex/application/dto/request/ExchangeRateRequest.java
+++ b/src/main/java/org/walrex/application/dto/request/ExchangeRateRequest.java
@@ -76,7 +76,17 @@ public record ExchangeRateRequest(
      * Si no se especifica, se usa 5.0 por defecto.
      */
     @DecimalMin(value = "0.0", message = "Margin must be 0 or greater")
-    BigDecimal margin
+    BigDecimal margin,
+
+    /**
+     * Tipo de cálculo para la tasa (MIN, MAX, PROMEDIO).
+     * Si no se especifica, se usa PROMEDIO por defecto.
+     */
+    @Pattern(
+            regexp = "^(MIN|MAX|PROMEDIO)$",
+            message = "Rate type must be MIN, MAX or PROMEDIO"
+    )
+    String typeRate
 ) {
     /**
      * Constructor que normaliza los datos.
@@ -91,6 +101,12 @@ public record ExchangeRateRequest(
         // Margen por defecto: 5%
         if (margin == null) {
             margin = BigDecimal.valueOf(5.0);
+        }
+        // Tipo de tasa por defecto: PROMEDIO
+        if (typeRate == null || typeRate.isBlank()) {
+            typeRate = "PROMEDIO";
+        } else {
+            typeRate = typeRate.toUpperCase().trim();
         }
     }
 }

--- a/src/main/java/org/walrex/application/dto/response/ExchangeRateResponse.java
+++ b/src/main/java/org/walrex/application/dto/response/ExchangeRateResponse.java
@@ -1,6 +1,8 @@
 package org.walrex.application.dto.response;
 
+import org.walrex.domain.model.ExchangeRate;
 import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * DTO de respuesta para cálculo de cambio de divisas.
@@ -54,6 +56,21 @@ public record ExchangeRateResponse(
         /**
          * Margen aplicado al cálculo (en porcentaje).
          */
-        BigDecimal marginApplied
+        BigDecimal marginApplied,
+
+        /**
+         * Listado de tasas de compra encontradas (Top 5).
+         */
+        List<ExchangeRate> advPriceBuy,
+
+        /**
+         * Listado de tasas de venta encontradas (Top 5).
+         */
+        List<ExchangeRate> advPriceSell,
+
+        /**
+         * Monto de USDT recibido en el primer tramo del cálculo.
+         */
+        BigDecimal usdtReceived
 ) {
 }

--- a/src/main/java/org/walrex/application/port/input/CalculateExchangeRateUseCase.java
+++ b/src/main/java/org/walrex/application/port/input/CalculateExchangeRateUseCase.java
@@ -12,6 +12,7 @@ public interface CalculateExchangeRateUseCase {
             String baseCurrency,
             String quoteCountry,
             String quoteCurrency,
-            BigDecimal margin
+            BigDecimal margin,
+            String typeRate
     );
 }

--- a/src/main/java/org/walrex/domain/model/ExchangeCalculation.java
+++ b/src/main/java/org/walrex/domain/model/ExchangeCalculation.java
@@ -1,6 +1,7 @@
 package org.walrex.domain.model;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * Modelo de dominio que representa el resultado de un cálculo de cambio de divisas.
@@ -52,6 +53,21 @@ public record ExchangeCalculation(
         /**
          * Margen aplicado al cálculo (en porcentaje).
          */
-        BigDecimal marginApplied
+        BigDecimal marginApplied,
+
+        /**
+         * Listado de tasas de compra encontradas (Top 5).
+         */
+        List<ExchangeRate> advPriceBuy,
+
+        /**
+         * Listado de tasas de venta encontradas (Top 5).
+         */
+        List<ExchangeRate> advPriceSell,
+
+        /**
+         * Monto de USDT recibido en el primer tramo del cálculo.
+         */
+        BigDecimal usdtReceived
 ) {
 }

--- a/src/main/java/org/walrex/domain/service/ExchangeRateCalculationService.java
+++ b/src/main/java/org/walrex/domain/service/ExchangeRateCalculationService.java
@@ -56,10 +56,11 @@ public class ExchangeRateCalculationService implements CalculateExchangeRateUseC
             String baseCurrency,
             String quoteCountry,
             String quoteCurrency,
-            BigDecimal margin) {
+            BigDecimal margin,
+            String typeRate) {
 
-        log.info("Calculating exchange rate: {} {} -> {}, margin: {}%",
-                amount, baseCurrency, quoteCurrency, margin);
+        log.info("Calculating exchange rate: {} {} -> {}, margin: {}%, typeRate: {}",
+                amount, baseCurrency, quoteCurrency, margin, typeRate);
 
         return remittanceRoutePort.findAllActiveExchangeRateRoutes()
                 .map(routes -> routes.stream()
@@ -69,7 +70,7 @@ public class ExchangeRateCalculationService implements CalculateExchangeRateUseC
                                 String.format("No active remittance route found for %s (%s) -> %s (%s)",
                                         baseCountry, baseCurrency, quoteCountry, quoteCurrency)))
                 )
-                .flatMap(route -> calculateCrossRate(amount, route, margin))
+                .flatMap(route -> calculateCrossRate(amount, route, margin, typeRate))
                 // Aplicar timeout proactivo de 25 segundos
                 .ifNoItem().after(CALCULATION_TIMEOUT).failWith(() -> {
                     log.error("Exchange rate calculation timed out after {} seconds for {} -> {}",
@@ -99,43 +100,63 @@ public class ExchangeRateCalculationService implements CalculateExchangeRateUseC
     private Uni<ExchangeCalculation> calculateCrossRate(
             BigDecimal amount,
             ExchangeRateRouteInfo route,
-            BigDecimal margin) {
+            BigDecimal margin,
+            String typeRate) {
 
         log.info("Calculating cross rate for route: {}:{} -> {}:{}", 
                 route.getCountryFromCode(), route.getCurrencyFromCode(), 
                 route.getCountryToCode(), route.getCurrencyToCode());
 
-        // Consultar métodos de pago y tasas en paralelo
-        Uni<BigDecimal> buyPriceUni = fetchAveragePriceForPair(route, true);
-        Uni<BigDecimal> sellPriceUni = fetchAveragePriceForPair(route, false);
-
-        return Uni.combine().all().unis(buyPriceUni, sellPriceUni).asTuple()
-                .map(tuple -> {
-                    BigDecimal avgBuyPrice = tuple.getItem1();
-                    BigDecimal avgSellPrice = tuple.getItem2();
-
-                    // Calcular USDT recibido
+        // 1. Buscar tasa de compra según monto fiat
+        return fetchRatesForPair(route, true, amount)
+                .flatMap(buyRates -> {
+                    // Calcular precio de compra (promedio, min o max de los top 5)
+                    BigDecimal avgBuyPrice = calculateRateByStrategy(buyRates, true, typeRate);
+                    
+                    // 2. Calcular USDT recibido
                     BigDecimal usdtReceived = calculateUsdtReceived(amount, avgBuyPrice);
+                    
+                    log.info("BUY Step: price={}, usdtReceived={}", avgBuyPrice, usdtReceived);
 
-                    return buildExchangeCalculation(
-                            amount,
-                            route.getCurrencyFromCode(),
-                            route.getCurrencyToCode(),
-                            avgBuyPrice,
-                            avgSellPrice,
-                            usdtReceived,
-                            margin
-                    );
+                    // 3. Buscar tasa de venta según USDT recibido
+                    return fetchRatesForPair(route, false, usdtReceived)
+                            .map(sellRates -> {
+                                BigDecimal avgSellPrice = calculateRateByStrategy(sellRates, false, typeRate);
+                                
+                                log.info("SELL Step: price={}", avgSellPrice);
+
+                                return buildExchangeCalculation(
+                                        amount,
+                                        route.getCurrencyFromCode(),
+                                        route.getCurrencyToCode(),
+                                        avgBuyPrice,
+                                        avgSellPrice,
+                                        usdtReceived,
+                                        margin,
+                                        buyRates.stream().limit(TOP_PRICES_LIMIT).toList(),
+                                        sellRates.stream().limit(TOP_PRICES_LIMIT).toList()
+                                );
+                            });
                 });
     }
 
     /**
-     * Obtiene el precio promedio (Top 5) para compra o venta.
+     * Obtiene el listado de tasas para un par y tipo de operación.
      */
-    private Uni<BigDecimal> fetchAveragePriceForPair(ExchangeRateRouteInfo route, boolean isBuy) {
+    private Uni<List<ExchangeRate>> fetchRatesForPair(ExchangeRateRouteInfo route, boolean isBuy, BigDecimal amount) {
         Long countryCurrencyId = isBuy ? route.getCountryCurrencyFromId() : route.getCountryCurrencyToId();
         String currency = isBuy ? route.getCurrencyFromCode() : route.getCurrencyToCode();
         String tradeType = isBuy ? TRADE_TYPE_BUY : TRADE_TYPE_SELL;
+
+        BigDecimal cryptoAmount = null;
+        if (!isBuy) {
+            cryptoAmount = amount;
+            amount = null;
+        }
+
+        // Variables effectively final para captura en la lambda
+        final BigDecimal finalFiatAmount = amount;
+        final BigDecimal finalCryptoAmount = cryptoAmount;
 
         return paymentMethodPort.findBinancePaymentCodesByCountryCurrency(countryCurrencyId)
                 .flatMap(payTypes -> exchangeRateProvider.fetchExchangeRates(
@@ -143,15 +164,15 @@ public class ExchangeRateCalculationService implements CalculateExchangeRateUseC
                         currency,
                         tradeType,
                         payTypes,
-                        null
-                ))
-                .map(rates -> calculateTop5Average(rates, isBuy));
+                        finalFiatAmount,
+                        finalCryptoAmount
+                ));
     }
 
     /**
-     * Calcula el promedio de las 5 mejores tasas.
+     * Calcula la tasa según la estrategia solicitada (MIN, MAX, PROMEDIO) sobre el Top 5.
      */
-    private BigDecimal calculateTop5Average(List<ExchangeRate> rates, boolean isBuy) {
+    private BigDecimal calculateRateByStrategy(List<ExchangeRate> rates, boolean isBuy, String typeRate) {
         if (rates == null || rates.isEmpty()) {
             throw new IllegalStateException("No exchange rates available for " + (isBuy ? "BUY" : "SELL"));
         }
@@ -164,8 +185,14 @@ public class ExchangeRateCalculationService implements CalculateExchangeRateUseC
                 .map(ExchangeRate::price)
                 .toList();
 
-        BigDecimal sum = topPrices.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
-        return sum.divide(BigDecimal.valueOf(topPrices.size()), SCALE, RoundingMode.HALF_UP);
+        return switch (typeRate.toUpperCase()) {
+            case "MIN" -> topPrices.stream().min(BigDecimal::compareTo).orElseThrow();
+            case "MAX" -> topPrices.stream().max(BigDecimal::compareTo).orElseThrow();
+            default -> { // PROMEDIO
+                BigDecimal sum = topPrices.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+                yield sum.divide(BigDecimal.valueOf(topPrices.size()), SCALE, RoundingMode.HALF_UP);
+            }
+        };
     }
 
     /**
@@ -185,7 +212,9 @@ public class ExchangeRateCalculationService implements CalculateExchangeRateUseC
             BigDecimal avgBuyPrice,
             BigDecimal avgSellPrice,
             BigDecimal usdtReceived,
-            BigDecimal margin) {
+            BigDecimal margin,
+            List<ExchangeRate> advPriceBuy,
+            List<ExchangeRate> advPriceSell) {
 
         // Tasa cruzada sin margen
         BigDecimal rate = avgSellPrice.divide(avgBuyPrice, SCALE, RoundingMode.HALF_UP);
@@ -209,7 +238,10 @@ public class ExchangeRateCalculationService implements CalculateExchangeRateUseC
                 rate,
                 exchangeRate,
                 convertedAmount,
-                margin
+                margin,
+                advPriceBuy,
+                advPriceSell,
+                usdtReceived
         );
     }
 }

--- a/src/main/java/org/walrex/infrastructure/adapter/inbound/rest/resource/ExchangeRateCalculationResource.java
+++ b/src/main/java/org/walrex/infrastructure/adapter/inbound/rest/resource/ExchangeRateCalculationResource.java
@@ -93,7 +93,8 @@ public class ExchangeRateCalculationResource {
                         request.baseCurrency(),
                         request.quoteCodeCountry(),
                         request.quoteCurrency(),
-                        request.margin()
+                        request.margin(),
+                        request.typeRate()
                 )
                 .map(exchangeRateMapper::toResponse)
                 .map(response -> Response.ok(response).build())

--- a/src/test/java/org/walrex/domain/service/ExchangeRateCalculationServiceTest.java
+++ b/src/test/java/org/walrex/domain/service/ExchangeRateCalculationServiceTest.java
@@ -91,16 +91,22 @@ class ExchangeRateCalculationServiceTest {
                 .thenReturn(Uni.createFrom().item(penPaymentMethods));
         when(paymentMethodPort.findBinancePaymentCodesByCountryCurrency(2L))
                 .thenReturn(Uni.createFrom().item(vesPaymentMethods));
+        
+        // Mock buy rates (BUY USDT/PEN with amount)
         when(exchangeRateProvider.fetchExchangeRates(
-                eq("USDT"), eq("PEN"), eq("BUY"), eq(penPaymentMethods), isNull()))
+                eq("USDT"), eq("PEN"), eq("BUY"), eq(penPaymentMethods), eq(amount), isNull()))
                 .thenReturn(Uni.createFrom().item(buyRates));
+        
+        // Mock sell rates (SELL USDT/VES with usdtReceived = 100/3.80 = 26.31578947)
+        // Note: The service calculates it with SCALE=8
+        BigDecimal expectedUsdtReceived = amount.divide(new BigDecimal("3.80"), 8, java.math.RoundingMode.HALF_UP);
         when(exchangeRateProvider.fetchExchangeRates(
-                eq("USDT"), eq("VES"), eq("SELL"), eq(vesPaymentMethods), isNull()))
+                eq("USDT"), eq("VES"), eq("SELL"), eq(vesPaymentMethods), isNull(), eq(expectedUsdtReceived)))
                 .thenReturn(Uni.createFrom().item(sellRates));
 
         // Act
         ExchangeCalculation result = service
-                .calculateExchangeRate(amount, baseCountry, baseCurrency, quoteCountry, quoteCurrency, margin)
+                .calculateExchangeRate(amount, baseCountry, baseCurrency, quoteCountry, quoteCurrency, margin, "PROMEDIO")
                 .await()
                 .indefinitely();
 
@@ -125,6 +131,14 @@ class ExchangeRateCalculationServiceTest {
 
         // La tasa con margen debe ser menor que la tasa sin margen (dividimos para aplicar margen)
         assertTrue(result.exchangeRate().compareTo(result.rate()) < 0);
+
+        // Verificar nuevos campos
+        assertNotNull(result.advPriceBuy());
+        assertNotNull(result.advPriceSell());
+        assertNotNull(result.usdtReceived());
+        assertEquals(5, result.advPriceBuy().size());
+        assertEquals(5, result.advPriceSell().size());
+        assertEquals(0, result.usdtReceived().compareTo(expectedUsdtReceived));
     }
 
     @Test
@@ -142,7 +156,7 @@ class ExchangeRateCalculationServiceTest {
 
         // Act & Assert
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                service.calculateExchangeRate(amount, baseCountry, baseCurrency, quoteCountry, quoteCurrency, margin)
+                service.calculateExchangeRate(amount, baseCountry, baseCurrency, quoteCountry, quoteCurrency, margin, "PROMEDIO")
                         .await()
                         .indefinitely()
         );
@@ -175,17 +189,115 @@ class ExchangeRateCalculationServiceTest {
                         .build())));
         when(paymentMethodPort.findBinancePaymentCodesByCountryCurrency(anyLong()))
                 .thenReturn(Uni.createFrom().item(List.of("Yape")));
-        when(exchangeRateProvider.fetchExchangeRates(any(), any(), any(), any(), any()))
+        when(exchangeRateProvider.fetchExchangeRates(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Uni.createFrom().item(Collections.emptyList()));
 
         // Act & Assert
         IllegalStateException exception = assertThrows(IllegalStateException.class, () ->
-                service.calculateExchangeRate(amount, baseCountry, baseCurrency, quoteCountry, quoteCurrency, margin)
+                service.calculateExchangeRate(amount, baseCountry, baseCurrency, quoteCountry, quoteCurrency, margin, "PROMEDIO")
                         .await()
                         .indefinitely()
         );
 
         assertTrue(exception.getMessage().contains("No exchange rates available"));
+    }
+
+    @Test
+    void shouldCalculateExchangeRateWithTypeRateMin() {
+        // Arrange
+        BigDecimal amount = BigDecimal.valueOf(100.00);
+        BigDecimal margin = BigDecimal.valueOf(5.0);
+
+        ExchangeRateRouteInfo route = ExchangeRateRouteInfo.builder()
+                .countryCurrencyFromId(1L).currencyFromId(1)
+                .countryFromCode("PE").currencyFromCode("PEN")
+                .countryCurrencyToId(2L).currencyToId(2)
+                .countryToCode("VE").currencyToCode("VES")
+                .intermediaryAsset("USDT").build();
+
+        List<String> penPaymentMethods = List.of("Yape");
+        List<String> vesPaymentMethods = List.of("PagoMovil");
+
+        List<ExchangeRate> buyRates = List.of(
+                createMockRate("3.78"), createMockRate("3.79"), createMockRate("3.80"),
+                createMockRate("3.81"), createMockRate("3.82")
+        );
+        List<ExchangeRate> sellRates = List.of(
+                createMockRate("36.50"), createMockRate("36.45"), createMockRate("36.55"),
+                createMockRate("36.48"), createMockRate("36.52")
+        );
+
+        // Con typeRate=MIN en compra, el precio resultante es el mínimo del top5 ordenado asc = 3.78
+        BigDecimal expectedBuyPrice = new BigDecimal("3.78");
+        BigDecimal expectedUsdtReceived = amount.divide(expectedBuyPrice, 8, java.math.RoundingMode.HALF_UP);
+
+        when(remittanceRoutePort.findAllActiveExchangeRateRoutes()).thenReturn(Uni.createFrom().item(List.of(route)));
+        when(paymentMethodPort.findBinancePaymentCodesByCountryCurrency(1L)).thenReturn(Uni.createFrom().item(penPaymentMethods));
+        when(paymentMethodPort.findBinancePaymentCodesByCountryCurrency(2L)).thenReturn(Uni.createFrom().item(vesPaymentMethods));
+        when(exchangeRateProvider.fetchExchangeRates(eq("USDT"), eq("PEN"), eq("BUY"), eq(penPaymentMethods), eq(amount), isNull()))
+                .thenReturn(Uni.createFrom().item(buyRates));
+        when(exchangeRateProvider.fetchExchangeRates(eq("USDT"), eq("VES"), eq("SELL"), eq(vesPaymentMethods), isNull(), eq(expectedUsdtReceived)))
+                .thenReturn(Uni.createFrom().item(sellRates));
+
+        // Act
+        ExchangeCalculation result = service
+                .calculateExchangeRate(amount, "PE", "PEN", "VE", "VES", margin, "MIN")
+                .await().indefinitely();
+
+        // Assert: el averageBuyPrice debe ser el mínimo = 3.78
+        assertEquals(0, result.averageBuyPrice().compareTo(new BigDecimal("3.78")));
+        assertNotNull(result.advPriceBuy());
+        assertNotNull(result.advPriceSell());
+        assertEquals(0, result.usdtReceived().compareTo(expectedUsdtReceived));
+    }
+
+    @Test
+    void shouldCalculateExchangeRateWithTypeRateMax() {
+        // Arrange
+        BigDecimal amount = BigDecimal.valueOf(100.00);
+        BigDecimal margin = BigDecimal.valueOf(5.0);
+
+        ExchangeRateRouteInfo route = ExchangeRateRouteInfo.builder()
+                .countryCurrencyFromId(1L).currencyFromId(1)
+                .countryFromCode("PE").currencyFromCode("PEN")
+                .countryCurrencyToId(2L).currencyToId(2)
+                .countryToCode("VE").currencyToCode("VES")
+                .intermediaryAsset("USDT").build();
+
+        List<String> penPaymentMethods = List.of("Yape");
+        List<String> vesPaymentMethods = List.of("PagoMovil");
+
+        List<ExchangeRate> buyRates = List.of(
+                createMockRate("3.78"), createMockRate("3.79"), createMockRate("3.80"),
+                createMockRate("3.81"), createMockRate("3.82")
+        );
+        List<ExchangeRate> sellRates = List.of(
+                createMockRate("36.50"), createMockRate("36.45"), createMockRate("36.55"),
+                createMockRate("36.48"), createMockRate("36.52")
+        );
+
+        // Con typeRate=MAX en compra, el precio resultante es el máximo del top5 ordenado asc = 3.82
+        BigDecimal expectedBuyPrice = new BigDecimal("3.82");
+        BigDecimal expectedUsdtReceived = amount.divide(expectedBuyPrice, 8, java.math.RoundingMode.HALF_UP);
+
+        when(remittanceRoutePort.findAllActiveExchangeRateRoutes()).thenReturn(Uni.createFrom().item(List.of(route)));
+        when(paymentMethodPort.findBinancePaymentCodesByCountryCurrency(1L)).thenReturn(Uni.createFrom().item(penPaymentMethods));
+        when(paymentMethodPort.findBinancePaymentCodesByCountryCurrency(2L)).thenReturn(Uni.createFrom().item(vesPaymentMethods));
+        when(exchangeRateProvider.fetchExchangeRates(eq("USDT"), eq("PEN"), eq("BUY"), eq(penPaymentMethods), eq(amount), isNull()))
+                .thenReturn(Uni.createFrom().item(buyRates));
+        when(exchangeRateProvider.fetchExchangeRates(eq("USDT"), eq("VES"), eq("SELL"), eq(vesPaymentMethods), isNull(), eq(expectedUsdtReceived)))
+                .thenReturn(Uni.createFrom().item(sellRates));
+
+        // Act
+        ExchangeCalculation result = service
+                .calculateExchangeRate(amount, "PE", "PEN", "VE", "VES", margin, "MAX")
+                .await().indefinitely();
+
+        // Assert: el averageBuyPrice debe ser el máximo = 3.82
+        assertEquals(0, result.averageBuyPrice().compareTo(new BigDecimal("3.82")));
+        assertNotNull(result.advPriceBuy());
+        assertNotNull(result.advPriceSell());
+        assertEquals(0, result.usdtReceived().compareTo(expectedUsdtReceived));
     }
 
     /**


### PR DESCRIPTION
Closes #88\n\nEste PR implementa las funcionalidades requeridas:\n\n- **Nuevos campos en ExchangeCalculation**: `advPriceBuy`, `advPriceSell` y `usdtReceived`.\n- **Soporte para `typeRate`**: Nueva propiedad en `ExchangeRateRequest` que soporta valores `MIN`, `MAX` y `PROMEDIO` (por defecto), cambiando la estrategia sobre cómo se promedian los 5 mejores precios.\n- **Flujo secuencial de cálculo**: Recálculo del `usdtReceived` en el primer paso (compra) para ser usado explícitamente como la cantidad (`cryptoAmount`) al consultar las tasas de venta.\n- **Pruebas actualizadas**: Tests adaptados para validar el flujo secuencial y nuevas pruebas para `typeRate=MIN` y `typeRate=MAX`.